### PR TITLE
ci: bump GitHub Actions to versions targeting Node.js 24

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -37,12 +37,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
         
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           
@@ -70,9 +70,9 @@ jobs:
           PYTHONPATH=src pytest tests/security/ -v
           
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
 
@@ -87,12 +87,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         
       - name: Build Docker image
         run: |
@@ -158,12 +158,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
         
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           
@@ -178,7 +178,7 @@ jobs:
           PYTHONPATH=src pytest tests/performance/ --benchmark-only --benchmark-json=benchmark.json -v
           
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-results
           path: benchmark.json


### PR DESCRIPTION
## Summary

Fixes the Node.js 20 deprecation warnings seen on `Run Tests`, `Performance Benchmark`, and `Docker Build Test (han_serif|handwritten)`:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: ...

Bumped each affected action in `.github/workflows/ci-pipeline.yml` to the first major release that natively targets `node24` (verified directly against each action's `action.yml` on GitHub, not just picking the latest tag):

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | v4 (node20) | v5 (node24) | |
| `actions/setup-python` | v4 (node20) | v6 (node24) | v5 is still node20 |
| `actions/upload-artifact` | v4 (node20) | v6 (node24) | v5 is still node20 |
| `docker/setup-buildx-action` | v3 (node20) | v4 (node24) | |
| `codecov/codecov-action` | v3 (node16) | v5 (composite) | input renamed `file:` → `files:` (removed in v4+) |

## Test plan

- [x] Confirmed each target version's `action.yml` via `curl https://raw.githubusercontent.com/<action>/<tag>/action.yml` before picking it (not guessed)
- [x] lefthook pre-push hooks (core-tests, quality-basic, security, security-scan-light) passed on push
- [ ] Actual CI run on this PR should no longer show the Node.js 20 deprecation annotations